### PR TITLE
Fix test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@react-native-community/netinfo": "^5.9.3",
     "@testing-library/react": "^10.4.8",
     "@testing-library/react-hooks": "^3.4.1",
-    "@testing-library/react-native": "^7.1.0",
+    "@testing-library/react-native": "^7.0.2",
     "@types/invariant": "^2.2.30",
     "@types/jest": "^26.0.10",
     "@types/react": "^16.7.22",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@react-native-community/netinfo": "^5.9.3",
     "@testing-library/react": "^10.4.8",
     "@testing-library/react-hooks": "^3.4.1",
+    "@testing-library/react-native": "^7.1.0",
     "@types/invariant": "^2.2.30",
     "@types/jest": "^26.0.10",
     "@types/react": "^16.7.22",

--- a/src/__tests__/usePresenceChannel.tsx
+++ b/src/__tests__/usePresenceChannel.tsx
@@ -2,7 +2,7 @@ import {
   actAndFlushPromises,
   makeAuthPusherConfig,
   renderHookWithProvider,
-} from "../../testUtils";
+} from "../testUtils";
 
 import { PusherMock } from "pusher-js-mock";
 import { act } from "@testing-library/react-hooks";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,6 +1710,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@react-native-community/cli-debugger-ui@^4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.9.0.tgz#4177764ba69243c97aa26829d59d9501acb2bd71"
@@ -1863,6 +1874,13 @@
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.3.0"
+
+"@testing-library/react-native@^7.1.0":
+  version "7.1.0"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/@testing-library/react-native/-/react-native-7.1.0.tgz#6b168aac21522c8a5175461b350336fd79612ac9"
+  integrity sha1-axaKrCFSLIpRdUYbNQM2/XlhKsk=
+  dependencies:
+    pretty-format "^26.0.1"
 
 "@testing-library/react@^10.4.8":
   version "10.4.8"
@@ -6198,6 +6216,16 @@ pretty-format@^25.1.0, pretty-format@^25.2.0, pretty-format@^25.2.1, pretty-form
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.1:
+  version "26.6.2"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha1-41wnBfFMt/4v6U+geDRbREEg/JM=
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^26.4.0:
   version "26.4.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.0.tgz#c08073f531429e9e5024049446f42ecc9f933a3b"
@@ -6328,6 +6356,11 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://packages.convoy.com/artifactory/api/npm/npm/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha1-WzUxvXamRaTJ+25pPtNkGeMwEzk=
 
 react-native-typescript-transformer@^1.2.13:
   version "1.2.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,10 +1875,10 @@
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.3.0"
 
-"@testing-library/react-native@^7.1.0":
-  version "7.1.0"
-  resolved "https://packages.convoy.com/artifactory/api/npm/npm/@testing-library/react-native/-/react-native-7.1.0.tgz#6b168aac21522c8a5175461b350336fd79612ac9"
-  integrity sha1-axaKrCFSLIpRdUYbNQM2/XlhKsk=
+"@testing-library/react-native@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.0.2.tgz#fd00b4c5639f606a07b20d0fec5a4cbfc3851efa"
+  integrity sha512-mOnsEgdbIvXa2cpZz+DTWiqtgObHRICujBGVXHVc1Wr9HbD7mMXIVPiOaUZPL6Wufw23FTy1pqAUIuQydtBc1Q==
   dependencies:
     pretty-format "^26.0.1"
 


### PR DESCRIPTION
Re-add `@testing-library/react-native`. Fix missed test path issue.

There is still a remaining failure in `examples` due to `expo-status-bar` that does not seem related. Reverting to previous version before any changes also had a failure. The test was not being run via `yarn test` due to `rn` vs `native` typo.