### PR TITLE
Sketching multichannel support

### DIFF
--- a/src/core/useChannels.ts
+++ b/src/core/useChannels.ts
@@ -20,13 +20,20 @@ export const NO_CHANNEL_NAME_WARNING =
   "No channel name passed to useChannel. No channel has been subscribed to.";
 
 export function useChannels<T extends Channel & PresenceChannel>(
-  channelNames: string[]
+  channelNames: string[] | undefined
 ) {
   const { client } = usePusher();
   const [channels, setChannels] = useState<T[] | undefined>();
+  const sortedJoinedChannelNames = (channelNames || []).sort().join(".");
   useEffect(() => {
     /** Return early if there's no client */
     if (!client) return;
+
+    /** Return early and warn if there's no channels */
+    if (channelNames === undefined || channelNames.length === 0) {
+      console.warn(NO_CHANNEL_NAME_WARNING);
+      return;
+    }
 
     /** Subscribe to channels and set it in state */
     const pusherChannels = channelNames.map((cn) => client.subscribe(cn));
@@ -34,7 +41,7 @@ export function useChannels<T extends Channel & PresenceChannel>(
 
     /** Cleanup on unmount/re-render */
     return () => channelNames.forEach((cn) => client?.unsubscribe(cn));
-  }, [channelNames.sort().join("."), client]);
+  }, [sortedJoinedChannelNames, client]);
 
   /** Return the channel for use. */
   return channels;

--- a/src/core/useChannels.ts
+++ b/src/core/useChannels.ts
@@ -1,0 +1,41 @@
+import { Channel, PresenceChannel } from "pusher-js";
+import { useEffect, useState } from "react";
+import { usePusher } from "./usePusher";
+
+/**
+ * Subscribe to a channel
+ *
+ * @param channelName The name of the channel you want to subscribe to.
+ * @typeparam Type of channel you're subscribing to. Can be one of `Channel` or `PresenceChannel` from `pusher-js`.
+ * @returns Instance of the channel you just subscribed to.
+ *
+ * @example
+ * ```javascript
+ * const channel = useChannel("my-channel")
+ * channel.bind('some-event', () => {})
+ * ```
+ */
+
+export const NO_CHANNEL_NAME_WARNING =
+  "No channel name passed to useChannel. No channel has been subscribed to.";
+
+export function useChannels<T extends Channel & PresenceChannel>(
+  channelNames: string[]
+) {
+  const { client } = usePusher();
+  const [channels, setChannels] = useState<T[] | undefined>();
+  useEffect(() => {
+    /** Return early if there's no client */
+    if (!client) return;
+
+    /** Subscribe to channels and set it in state */
+    const pusherChannels = channelNames.map((cn) => client.subscribe(cn));
+    setChannels(pusherChannels as T);
+
+    /** Cleanup on unmount/re-render */
+    return () => channelNames.forEach((cn) => client?.unsubscribe(cn));
+  }, [channelNames.sort().join("."), client]);
+
+  /** Return the channel for use. */
+  return channels;
+}

--- a/src/core/useEvent.ts
+++ b/src/core/useEvent.ts
@@ -10,7 +10,7 @@ import { useEffect } from "react";
  * @param callback Callback to call on a new event
  */
 export function useEvent<D>(
-  channel: Channel | PresenceChannel | undefined,
+  channel: Channel | Channel[] | PresenceChannel | undefined,
   eventName: string,
   callback: (data?: D, metadata?: { user_id: string }) => void
 ) {
@@ -22,9 +22,13 @@ export function useEvent<D>(
   useEffect(() => {
     if (channel === undefined) {
       return;
+    } else if (Array.isArray(channel)) {
+      channel.forEach((cn) => cn.bind(eventName, callback));
     } else channel.bind(eventName, callback);
     return () => {
-      channel.unbind(eventName, callback);
+      if (Array.isArray(channel)) {
+        channel.forEach((cn) => cn.bind(eventName, callback));
+      } else channel.unbind(eventName, callback);
     };
   }, [channel, eventName, callback]);
 }

--- a/src/core/useEvent.ts
+++ b/src/core/useEvent.ts
@@ -10,7 +10,7 @@ import { useEffect } from "react";
  * @param callback Callback to call on a new event
  */
 export function useEvent<D>(
-  channel: Channel | Channel[] | PresenceChannel | undefined,
+  channel: Channel | Channel[] | PresenceChannel | PresenceChannel[] | undefined,
   eventName: string,
   callback: (data?: D, metadata?: { user_id: string }) => void
 ) {
@@ -24,11 +24,16 @@ export function useEvent<D>(
       return;
     } else if (Array.isArray(channel)) {
       channel.forEach((cn) => cn.bind(eventName, callback));
-    } else channel.bind(eventName, callback);
+    } else {
+      channel.bind(eventName, callback);
+    }
+
     return () => {
       if (Array.isArray(channel)) {
-        channel.forEach((cn) => cn.bind(eventName, callback));
-      } else channel.unbind(eventName, callback);
+        channel.forEach((cn) => cn.unbind(eventName, callback));
+      } else {
+        channel.unbind(eventName, callback);
+      }
     };
   }, [channel, eventName, callback]);
 }


### PR DESCRIPTION
My company is using the library. We have a component that loads a set of objects and we want to subscribe to a channel per each. The set of objects starts empty, so when they are loaded this leads to a different number of hooks being called. We do not know how many objects there will be ahead of time.

So, I thought, why not allow passing multiple channels into a single hook? This is a sketch of that functionality. I ended up creating a `useChannels` function and then modifying `useEvent`. This is just a quick and dirty illustration of the idea, perhaps it would be better to modify `useChannel` or to create a new event hook for multiple channels.

What do you think? Is there a better solution to this problem or could this be useful functionality?
