### PR TITLE
chore(package): remove react peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harelpls/use-pusher",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "A wrapper around pusher-js for easy-as hooks in React.",
   "author": "@mayteio",
   "keywords": [
@@ -43,9 +43,6 @@
     "dequal": "^2.0.1",
     "invariant": "^2.2.4",
     "pusher-js": "^7.0.0"
-  },
-  "peerDependencies": {
-    "react": "^16.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",


### PR DESCRIPTION
guardrails like this peer dep are a virtue, but afaik there's no way to have an explicit peer dep@^16.9.0 cross the major release boundary to ^17.x

this is causing problems for installing in apps that use react@17+, which now require a SKIP_PREFLIGHT_CHECK flag

maybe the README would be a better place for explicitly stating React@^16.9.0 is required for proper functioning?
