### PR TITLE
Remove console warning for falsy channel

### DIFF
--- a/docs/modules/_core_usechannel_.html
+++ b/docs/modules/_core_usechannel_.html
@@ -88,9 +88,6 @@
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Variables</h2>
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module">
-					<a name="no_channel_name_warning" class="tsd-anchor"></a>
-					<h3><span class="tsd-flag ts-flagConst">Const</span> NO_<wbr>CHANNEL_<wbr>NAME_<wbr>WARNING</h3>
-					<div class="tsd-signature tsd-kind-icon">NO_<wbr>CHANNEL_<wbr>NAME_<wbr>WARNING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"No channel name passed to useChannel. No channel has been subscribed to."</span><span class="tsd-signature-symbol"> = &quot;No channel name passed to useChannel. No channel has been subscribed to.&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in core/useChannel.ts:19</li>
@@ -108,7 +105,7 @@
 							<dd><p>of channel you&#39;re subscribing to. Can be one of <code>Channel</code> or <code>PresenceChannel</code> from <code>pusher-js</code>.</p>
 							</dd>
 							<dt>returns</dt>
-							<dd><p>Instance of the channel you just subscribed to.</p>
+              <dd><p>Instance of the channel you just subscribed to (or <code>undefined</code> if the channel name provided is falsy).</p>
 							</dd>
 							<dt>example</dt>
 							<dd><pre><code class="language-javascript"><span class="hljs-keyword">const</span> channel = useChannel(<span class="hljs-string">&quot;my-channel&quot;</span>)

--- a/src/__tests__/useChannel.tsx
+++ b/src/__tests__/useChannel.tsx
@@ -2,18 +2,20 @@ import { PusherChannelMock } from "pusher-js-mock";
 import React from "react";
 import { renderHook } from "@testing-library/react-hooks";
 import { renderHookWithProvider } from "../testUtils";
-import { useChannel, NO_CHANNEL_NAME_WARNING } from "../core/useChannel";
+import { useChannel } from "../core/useChannel";
 import { __PusherContext } from "../core/PusherProvider";
 
 describe("useChannel()", () => {
-  test("should throw an error when no channelName present", () => {
+  test("should return undefined when channelName is falsy", () => {
     const wrapper: React.FC = (props) => (
       <__PusherContext.Provider value={{ client: {} as any }} {...props} />
     );
 
-    jest.spyOn(console, "warn");
-    renderHook(() => useChannel(undefined), { wrapper });
-    expect(console.warn).toHaveBeenCalledWith(NO_CHANNEL_NAME_WARNING);
+    const { result } = renderHook(() => useChannel(""), {
+      wrapper,
+    });
+
+    expect(result.current).toBeUndefined();
   });
 
   test("should return undefined if no pusher client present", () => {

--- a/src/core/useChannel.ts
+++ b/src/core/useChannel.ts
@@ -16,9 +16,6 @@ import { usePusher } from "./usePusher";
  * ```
  */
 
-export const NO_CHANNEL_NAME_WARNING =
-  "No channel name passed to useChannel. No channel has been subscribed to.";
-
 export function useChannel<T extends Channel & PresenceChannel>(
   channelName: string | undefined
 ) {
@@ -28,11 +25,8 @@ export function useChannel<T extends Channel & PresenceChannel>(
     /** Return early if there's no client */
     if (!client) return;
 
-    /** Return early and warn if there's no channel */
-    if (!channelName) {
-      console.warn(NO_CHANNEL_NAME_WARNING);
-      return;
-    }
+    /** Return early if channel name is falsy */
+    if (!channelName) return;
 
     /** Subscribe to channel and set it in state */
     const pusherChannel = client.subscribe(channelName);


### PR DESCRIPTION
Addresses #44. 

# Current Behavior:
If `useChannel` is passed a falsy value, it returns early with a console warning.

# Proposed Behavior:
Don't emit the console warning (for my usage of this hook, it's a feature not a bug!)

p.s. I love this library—a huge help!